### PR TITLE
Update surgery loading header check

### DIFF
--- a/SERVER/server/SurgerySchedulerSA/test_io.cpp
+++ b/SERVER/server/SurgerySchedulerSA/test_io.cpp
@@ -1,0 +1,12 @@
+#include "io.h"
+#include <iostream>
+
+int main() {
+    auto surgeries = loadSurgeries("TimeTable.csv");
+    if (surgeries.empty()) {
+        std::cerr << "no surgeries loaded\n";
+        return 1;
+    }
+    std::cout << surgeries[0].applyId << " " << surgeries[0].room << "\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- improve detection of CSV headers in `loadSurgeries`
- parse first record when no header is found
- add small example `test_io.cpp` demonstrating usage

## Testing
- `g++ test_io.cpp io.cpp -o test_io -std=c++17`
- `./test_io`

------
https://chatgpt.com/codex/tasks/task_e_6856bb0b30c88333a118646266787d74